### PR TITLE
Use Java 8 + Support Elasticsearch 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,12 @@ elasticsearch_cluster_name = elasticsearch1-somedc-prod
 # to false, we will use unicast discovery
 # instead (as in, we will add all nodes)
 # to configuration instead of relying on multicasting
-#
-elasticsearch_autodiscovery = true
+# For production, set to false.
+# Default: false.
+elasticsearch_autodiscovery = false
+
+# Default multicast port
+elasticsearch_autodiscovery_port = 54328
 
 # ElasticSearch heap size (default: 256m)
 # http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/heap-sizing.html
@@ -47,7 +51,14 @@ elasticsearch_heap_size = 1g
 
 # Version of ElasticDump to install
 elasticdump_version = v0.12.0
+
+# Default Elasticsearch version.
+# Note: Ensure the meta/main.yml file uses the corresponding repository. (e.g. `elasticsearch-2.x`, `elasticsearch-1.7`, etc.)
+# See https://github.com/AerisCloud/ansible-repos for corresponding repositories.
+elasticsearch_version = 2.1.1
 ```
+
+
 
 ### Execution
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 elasticsearch_tcp_port: 19350
 elasticsearch_http_port: 9200
-elasticsearch_autodiscovery: true
+elasticsearch_autodiscovery: false
 elasticsearch_heap_size: 256m
 
 elasticdump_version: v0.12.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     - name: Debian
       versions:
         - wheezy
+        - jessie
   categories:
     - database
     - database:nosql
@@ -21,7 +22,12 @@ dependencies:
   - role: aeriscloud.repos
     repositories:
       centos6:
-        - elasticsearch
+        - elasticsearch-2.x
       centos7:
-        - elasticsearch
+        - elasticsearch-2.x
+      wheezy:
+        - elasticsearch-2.x
+      jessie:
+        - backports
+        - elasticsearch-2.x
   - role: aeriscloud.yum

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -1,36 +1,38 @@
-- name: "Set elasticsearch version"
-  set_fact:
-    es_ver: "{{ elasticsearch_version[:3] }}"
-  tags:
-    - pkgs
-    - elasticsearch
-
-- name: "Download and install the Public Signing Key"
-  rpm_key: >
-    key=https://packages.elastic.co/GPG-KEY-elasticsearch
-    state=present
-  tags:
-    - pkgs
-    - elasticsearch
-
 - name: "Install Elasticsearch and its dependencies"
   yum: >
     name={{ item }}
     state=present
-    enablerepo=elasticsearch-{{ es_ver }}
+    enablerepo=elasticsearch
   with_items:
-    - java-1.7.0-openjdk
+    - java-1.8.0-openjdk
     - elasticsearch-{{ elasticsearch_version }}
+  register: elasticsearch_installed
   tags:
     - pkgs
     - elasticsearch
   notify:
     - Restart ElasticSearch
 
+# Currently, when a new systemd service file is uploaded, Ansible does not reload the
+# systemd daemon. So the service file that's just been uploaded is not recognized.
+# Systemd daemon needs to be restarted to see the updated service file.
+# The link below discusses whether systemctl should automatically reload the systemd daemon.
+# https://github.com/ansible/ansible-modules-core/issues/191
+- name: "Reload the Systemd daemon"
+  shell: >
+    systemctl daemon-reload
+  when: elasticsearch_installed|changed and ansible_distribution_major_version|int == 7
+  tags:
+    - elasticsearch
+    - files
+    - service
+
 - name: "Configure Elasticsearch to automatically start during bootup"
   service:
     name=elasticsearch
+    runlevel="95 10"
     enabled=yes
+  when: elasticsearch_installed|changed and ansible_distribution_major_version|int == 7
   tags:
     - pkgs
     - elasticsearch

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,25 +1,3 @@
-- name: "Set elasticsearch version"
-  set_fact:
-    es_ver: "{{ elasticsearch_version[:3] }}"
-  tags:
-    - elasticsearch
-
-- name: "Download and install the Public Signing Key"
-  apt_key: >
-    url=https://packages.elasticsearch.org/GPG-KEY-elasticsearch
-    state=present
-  tags:
-    - elasticsearch
-    - pkgs
-
-- name: "Add Elasticsearch apt repository"
-  apt_repository: >
-    repo="deb http://packages.elasticsearch.org/elasticsearch/{{ es_ver }}/debian stable main"
-    state=present
-  tags:
-    - elasticsearch
-    - repos
-
 - name: "Install Elasticsearch's dependencies"
   apt: >
     name={{ item }}
@@ -27,24 +5,40 @@
     update_cache=yes
   with_items:
     - openjdk-7-jre-headless
+  when: ansible_distribution_release == "wheezy"
   tags:
     - elasticsearch
     - pkgs
 
-- name: "Check if Java 7 as the default"
+- name: "Install Elasticsearch's dependencies"
+  apt: >
+    name={{ item }}
+    state=present
+    update_cache=yes
+    default_release={{ ansible_distribution_release }}-backports
+  with_items:
+    - openjdk-8-jre-headless
+  when: ansible_distribution_release == "jessie"
+  tags:
+    - elasticsearch
+    - pkgs
+
+- name: "Check if Java 8 as the default"
   file: >
-    src=/usr/lib/jvm/java-1.7.0-openjdk-amd64/jre/bin/java
+    src=/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin/java
     dest=/etc/alternatives/java
     state=link
+  when: ansible_distribution_release == "jessie"
   register: java_set
   tags:
     - elasticsearch
     - files
 
-- name: "Ensure Java 7 is the default"
+- name: "Ensure Java 8 is the default"
   shell: |
     executable=/bin/bash
-    update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+    update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+  when: ansible_distribution_release == "jessie"
   when: java_set.changed
   tags:
     - elasticsearch
@@ -53,11 +47,26 @@
   apt: >
     update_cache=yes
     name=elasticsearch
+  register: elasticsearch_installed
   notify:
     - Restart ElasticSearch
   tags:
     - elasticsearch
     - pkgs
+
+# Currently, when a new systemd service file is uploaded, Ansible does not reload the
+# systemd daemon. So the service file that's just been uploaded is not recognized.
+# Systemd daemon needs to be restarted to see the updated service file.
+# The link below discusses whether systemctl should automatically reload the systemd daemon.
+# https://github.com/ansible/ansible-modules-core/issues/191
+- name: "Reload the Systemd daemon"
+  shell: >
+    systemctl daemon-reload
+  when: elasticsearch_installed|changed and ansible_distribution_release == "jessie"
+  tags:
+    - elasticsearch
+    - files
+    - service
 
 - name: "Configure Elasticsearch to automatically start during bootup"
   service: >

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -46,7 +46,7 @@
 - name: "Install Elasticsearch"
   apt: >
     update_cache=yes
-    name=elasticsearch
+    name=elasticsearch={{ elasticsearch_version }}
   register: elasticsearch_installed
   notify:
     - Restart ElasticSearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,12 +17,26 @@
     chdir=/usr/share/elasticsearch
     creates=/usr/share/elasticsearch/plugins/{{ item.dest }}
     
-    bin/plugin -install {{ item.src }}
+    bin/plugin install {{ item.src }}
   with_items:
     - src: royrusso/elasticsearch-HQ
-      dest: HQ
+      dest: hq
     - src: mobz/elasticsearch-head
       dest: head
+  tags:
+    - elasticsearch
+    - plugins
+
+- name: "Install ElasticSearch plugins"
+  shell: |
+    chdir=/usr/share/elasticsearch
+    creates=/usr/share/elasticsearch/plugins/{{ item.dest }}
+    
+    bin/plugin install {{ item.src }}
+  with_items:
+    - src: discovery-multicast
+      dest: discovery-multicast
+  when: elasticsearch_autodiscovery|string == "True"
   tags:
     - elasticsearch
     - plugins

--- a/templates/elasticsearch.yml
+++ b/templates/elasticsearch.yml
@@ -15,8 +15,12 @@ http.enabled: true
 
 # adapt these for discovery to work in your network! multicast can be tricky
 {% if elasticsearch_autodiscovery|string == "True" %}
+transport.publish_port: {{ elasticsearch_tcp_port }}
 discovery.zen.ping.multicast.address: {{ ansible_ssh_host }}
 discovery.zen.ping.multicast.group: 224.2.2.4
+discovery.zen.ping.multicast.enabled: true
+discovery.zen.ping.multicast.port: {{ elasticsearch_autodiscovery_port|default(54328) }}
+discovery.zen.ping.multicast.ttl: {{ elasticsearch_autodiscovery_ttl|default(3) }}
 {% else %}
 discovery.zen.ping.multicast.enabled: false
 discovery.zen.ping.unicast.hosts:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
-elasticsearch_version: "1.5.2"
-
-elasticsearch_node_version: "v0.10.38"
+elasticsearch_version: "2.1.1"
+elasticsearch_repo: "2.x"
+elasticsearch_node_version: "v0.10.40"


### PR DESCRIPTION
- Use Java 8.
- Support Elasticsearch 2.x
  - Defaults the Elasticsearch version to 2.1.1
  - [Autodiscovery](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html) is now off by default, because it's been [removed, but offered as a plugin](https://www.elastic.co/blog/elasticsearch-unplugged). Use `elasticsearch_autodiscovery=true` to use it.
  - bump `elasticsearch_node_version` to `0.10.40`

Requires https://github.com/AerisCloud/ansible-repos/pull/22
